### PR TITLE
chc_parse_file: add support for specifying compiler/cpu architecture

### DIFF
--- a/advance/cmdline/kendra/TestManager.py
+++ b/advance/cmdline/kendra/TestManager.py
@@ -132,7 +132,7 @@ class TestManager(object):
         if self.verbose: print('\nParsing files\n' + ('-' * 80))
         for cfile in self.get_cref_files():
             cfilename = cfile.name
-            ifilename = self.parsemanager.preprocess_file_with_gcc(cfilename,copyfiles=True)
+            ifilename = self.parsemanager.preprocess_file(cfilename,copyfiles=True)
             parseresult = self.parsemanager.parse_ifile(ifilename)
             if parseresult != 0:
                 self.testresults.add_parse_error(cfilename,str(parseresult))

--- a/advance/cmdline/sfapp/chc_parse_file.py
+++ b/advance/cmdline/sfapp/chc_parse_file.py
@@ -53,6 +53,8 @@ def parse():
     parser.add_argument('--savesemantics',
                             help='create gzipped tar file with semantics files',
                             action='store_true')
+    parser.add_argument('--compiler', help='compiler to use', default='gcc')
+    parser.add_argument('--cpuarch', help='target architecture', default=None)
     args = parser.parse_args()
     return args
 
@@ -102,12 +104,14 @@ if __name__ == '__main__':
             print('Removing semantics_linux.tar.gz')
             os.remove('semantics_linux.tar.gz')
     
-    parsemanager = ParseManager(cpath,targetpath)
+    parsemanager = ParseManager(cpath,targetpath,
+                                tgtcompiler=args.compiler,
+                                tgtcpuarch=args.cpuarch)
     parsemanager.initialize_paths()
 
     try:
         basename = os.path.basename(cfilename)
-        ifilename = parsemanager.preprocess_file_with_gcc(basename)
+        ifilename = parsemanager.preprocess_file(basename)
         result = parsemanager.parse_ifile(ifilename)
         if result != 0:
             print('*' * 80)


### PR DESCRIPTION
This abstracts the compiler and cpu architecture.
Only gcc and armcc (windows via wsl) are supported, cpu arch is only
used by armcc and the architecture option is not validated before
passing it on to the compiler.